### PR TITLE
[feat] Provider/Groq: Integrate Groq Provider into Supachain Library

### DIFF
--- a/src/main/kotlin/robot/messenger/Role.kt
+++ b/src/main/kotlin/robot/messenger/Role.kt
@@ -51,5 +51,8 @@ enum class Role {
     ASSISTANT,
 
     @SerialName("function")
-    FUNCTION
+    FUNCTION,
+
+    @SerialName("tool")
+    TOOL
 }

--- a/src/main/kotlin/robot/messenger/messaging/Components.kt
+++ b/src/main/kotlin/robot/messenger/messaging/Components.kt
@@ -43,6 +43,7 @@ data class AudioResponse(val model: String)
 @Serializable
 data class ImageResponse(val model: String)
 
+// TODO Move to common
 @Serializable
 data class ToolCall(val id: String, val type: String, val function: FunctionCall)
 

--- a/src/main/kotlin/robot/provider/Actions.kt
+++ b/src/main/kotlin/robot/provider/Actions.kt
@@ -7,7 +7,7 @@
  */
 package dev.supachain.robot.provider
 
-import dev.supachain.robot.provider.models.Message
+import dev.supachain.robot.provider.models.CommonMessage
 import dev.supachain.robot.tool.ToolConfig
 
 /**
@@ -24,32 +24,32 @@ internal interface Actions {
     val name: String
 
     suspend
-    fun chat(tools: List<ToolConfig>): Message =
+    fun chat(tools: List<ToolConfig>): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support chat, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun embedding(): Message =
+    fun embedding(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support embedding, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun moderation(): Message =
+    fun moderation(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support moderation, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun createSpeech(): Message =
+    fun createSpeech(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support createSpeech, try updating the project if $name supports this feature"
         )
 
     suspend
     fun createTranscription()
-            : Message =
+            : CommonMessage =
         throw NotImplementedError(
             "$name does not currently support createTranscription, try updating the project if $name supports this " +
                     "feature"
@@ -57,27 +57,27 @@ internal interface Actions {
 
     suspend
     fun createTranslation()
-            : Message =
+            : CommonMessage =
         throw NotImplementedError(
             "$name does not currently support createTranslation, try updating the project if $name supports this " +
                     "feature"
         )
 
     suspend
-    fun createFineTune(): Message =
+    fun createFineTune(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support createFineTune, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun listFineTunes(): Message =
+    fun listFineTunes(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support listFineTunes, try updating the project if $name supports this feature"
         )
 
     suspend
     fun listFineTuneEvents()
-            : Message =
+            : CommonMessage =
         throw NotImplementedError(
             "$name does not currently support listFineTuneEvents, try updating the project if $name supports this " +
                     "feature"
@@ -85,152 +85,152 @@ internal interface Actions {
 
     suspend
     fun listFineTuneCheckPoints()
-            : Message =
+            : CommonMessage =
         throw NotImplementedError(
             "$name does not currently support listFineTuneCheckPoints, try updating the project if $name supports this" +
                     " feature"
         )
 
     suspend
-    fun fineTuneInfo(): Message =
+    fun fineTuneInfo(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support fineTuneInfo, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun fineTuneCancel(): Message =
+    fun fineTuneCancel(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support fineTuneCancel, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun createBatch(): Message =
+    fun createBatch(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support createBatch, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun getBatch(): Message =
+    fun getBatch(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support getBatch, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun cancelBatch(): Message =
+    fun cancelBatch(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support cancelBatch, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun listBatches(): Message =
+    fun listBatches(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support listBatches, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun uploadFile(): Message =
+    fun uploadFile(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support uploadFile, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun listFiles(): Message =
+    fun listFiles(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support listFiles, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun getFile(): Message =
+    fun getFile(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support getFile, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun deleteFile(): Message =
+    fun deleteFile(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support deleteFile, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun getFileContent(): Message =
+    fun getFileContent(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support getFileContent, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun createImage(): Message =
+    fun createImage(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support createImage, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun readImage(): Message =
+    fun readImage(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support readImage, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun updateImage(): Message =
+    fun updateImage(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support updateImage, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun varyImage(): Message =
+    fun varyImage(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support varyImage, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun createAudio(): Message =
+    fun createAudio(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support createAudio, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun readAudio(): Message =
+    fun readAudio(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support readAudio, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun updateAudio(): Message =
+    fun updateAudio(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support updateAudio, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun varyAudio(): Message =
+    fun varyAudio(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support varyAudio, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun createVideo(): Message =
+    fun createVideo(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support createVideo, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun readVideo(): Message =
+    fun readVideo(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support readVideo, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun updateVideo(): Message =
+    fun updateVideo(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support updateVideo, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun varyVideo(): Message =
+    fun varyVideo(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support varyVideo, try updating the project if $name supports this feature"
         )
 
     suspend
-    fun listModels(): Message =
+    fun listModels(): CommonMessage =
         throw NotImplementedError(
             "$name does not currently support listModels, try updating the project if $name supports this feature"
         )

--- a/src/main/kotlin/robot/provider/Provider.kt
+++ b/src/main/kotlin/robot/provider/Provider.kt
@@ -4,7 +4,8 @@ package dev.supachain.robot.provider
 
 import dev.supachain.robot.messenger.MessageFilter
 import dev.supachain.robot.messenger.Messenger
-import dev.supachain.robot.provider.models.Message
+import dev.supachain.robot.messenger.messaging.ToolCall
+import dev.supachain.robot.provider.models.CommonMessage
 import dev.supachain.robot.tool.ToolConfig
 import dev.supachain.robot.tool.strategies.ToolUseStrategy
 
@@ -32,8 +33,8 @@ abstract class Provider<T : Provider<T>> {
     internal abstract val actions: Actions
 
     internal abstract val messenger: Messenger
-    internal abstract fun onToolResult(result: String)
-    internal abstract fun onReceiveMessage(message: Message)
+    internal abstract fun onToolResult(toolCall: ToolCall, result: String)
+    internal abstract fun onReceiveMessage(message: CommonMessage)
 
     /**
      * Executes a request to the AI provider for a specific feature.
@@ -51,7 +52,7 @@ abstract class Provider<T : Provider<T>> {
      * @since 0.1.0
      */
     internal suspend inline
-    fun request(feature: Feature, tools: List<ToolConfig>): Message =
+    fun request(feature: Feature, tools: List<ToolConfig>): CommonMessage =
         when (feature) {
             // Feature chat is chatting
             Feature.Chat -> actions.chat(tools.allowed)

--- a/src/main/kotlin/robot/provider/models/Common.kt
+++ b/src/main/kotlin/robot/provider/models/Common.kt
@@ -1,0 +1,39 @@
+package dev.supachain.robot.provider.models
+
+import dev.supachain.robot.tool.ToolConfig
+import dev.supachain.utilities.Parameter
+import kotlinx.serialization.Serializable
+
+fun List<ToolConfig>.asOpenAITools() = map { CommonTool.OpenAI(it) }
+interface CommonTool {
+    @Serializable
+    data class OpenAI(val type: String, val function: OpenAIFunction) {
+
+
+        constructor(toolConfig: ToolConfig) : this("function", OpenAIFunction(toolConfig))
+    }
+
+
+    @Serializable
+    data class OpenAIFunction(val name: String, val description: String?, val parameters: Parameters) {
+        @Serializable
+        data class Parameters(
+            val type: String,
+            val properties: Map<String, Property>,
+            val required: List<String>
+        ) {
+            constructor(parameters: List<Parameter>) : this(
+                "object",
+                parameters.toProperties(),
+                parameters.filter { it.required }.map { it.name }
+            )
+        }
+
+        constructor(toolConfig: ToolConfig) :
+                this(
+                    toolConfig.function.name,
+                    toolConfig.function.description.ifBlank { null },
+                    Parameters(toolConfig.function.parameters)
+                )
+    }
+}

--- a/src/main/kotlin/robot/provider/models/CommonMessage.kt
+++ b/src/main/kotlin/robot/provider/models/CommonMessage.kt
@@ -12,6 +12,7 @@ package dev.supachain.robot.provider.models
 
 import dev.supachain.robot.messenger.Role
 import dev.supachain.robot.messenger.messaging.FunctionCall
+import dev.supachain.robot.messenger.messaging.ToolCall
 import dev.supachain.utilities.toJson
 import kotlinx.serialization.Serializable
 
@@ -22,7 +23,7 @@ import kotlinx.serialization.Serializable
  * This interface serves as a base for different types of responses that different AI providers
  * might provide. It encapsulates the core elements of a response.
  *
- * @property functions Returns a list of FunctionCall objects requested by the provider.
+ * @property calls Returns a list of FunctionCall objects requested by the provider.
  * @property role Returns the role of the message sender.
  * @property text Returns the text content of the message.
  * @property contents Returns a list of contents in the message.
@@ -30,8 +31,8 @@ import kotlinx.serialization.Serializable
  * @since 0.1.0
  */
 @Serializable
-sealed interface Message {
-    fun functions(): List<FunctionCall> = contents().filterIsInstance<FunctionCall>()
+sealed interface CommonMessage {
+    fun calls(): List<ToolCall> = contents().filterIsInstance<ToolCall>()
     fun role(): Role = throw NotImplementedError()
     fun text(): TextContent = throw NotImplementedError()
     fun contents(): List<Content> = throw NotImplementedError()
@@ -45,25 +46,25 @@ sealed interface Message {
 /** Represents a text content in a message from an AI provider */
 @Serializable
 @JvmInline
-value class TextContent(val value: String) : Message.Content {
+value class TextContent(val value: String) : CommonMessage.Content {
     override fun toString() = value
 }
 
 /** Represents a function call in a message from an AI provider */
 @Serializable
 @JvmInline
-value class FunctionCallContent(val function: FunctionCall) : Message.Content {
+value class FunctionCallContent(val function: FunctionCall) : CommonMessage.Content {
     override fun toString() = "fun ${function.name}"
 }
 
 /** Represents Image in a message from an AI provider */
 @Serializable
-data class Base64ImageContent(val base64: String, val mediaType: String) : Message.Content
+data class Base64ImageContent(val base64: String, val mediaType: String) : CommonMessage.Content
 
 /** Represents Document in a message from an AI provider */
 @Serializable
 @JvmInline
-value class DocumentContent(val location: String) : Message.Content
+value class DocumentContent(val location: String) : CommonMessage.Content
 
 /**
  * Represents a text message exchanged within a conversation.
@@ -79,12 +80,12 @@ value class DocumentContent(val location: String) : Message.Content
 data class TextMessage(
     var role: Role,
     var content: String?,
-) : Message {
+) : CommonMessage {
     override fun toString() = this.toJson()
-    override fun functions(): List<FunctionCall> = emptyList()
+    override fun calls(): List<ToolCall> = emptyList()
     override fun role(): Role = this.role
     override fun text() = TextContent(content ?: "")
-    override fun contents(): List<Message.Content> = listOf(text())
+    override fun contents(): List<CommonMessage.Content> = listOf(text())
 }
 
 /** Converts any object into a system message for an AI conversation. */

--- a/src/main/kotlin/robot/provider/models/Groq.kt
+++ b/src/main/kotlin/robot/provider/models/Groq.kt
@@ -15,18 +15,31 @@ import dev.supachain.utilities.Parameter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-abstract class GroqBuilder : Provider<GroqBuilder>(), NetworkOwner {
+
+/*
+░░░░░░░░░░░░░░░░░░░░░░░░░░       ░░░  ░░░░  ░░        ░░  ░░░░░░░░       ░░░        ░░       ░░░░░░░░░░░░░░░░░░░░░░░░░░░
+▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓       ▓▓▓  ▓▓▓▓  ▓▓▓▓▓  ▓▓▓▓▓  ▓▓▓▓▓▓▓▓  ▓▓▓▓  ▓▓      ▓▓▓▓       ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+██████████████████████████  ████  ██  ████  █████  █████  ████████  ████  ██  ████████  ███  ███████████████████████████
+██████████████████████████       ████      ███        ██        ██       ███        ██  ████  ██████████████████████████
+*/
+@Suppress("unused")
+abstract class GroqBuilder : Provider<GroqBuilder>(), NetworkOwner, GroqModels {
+    abstract val model: String
     var apiKey: String = ""
+    var frequencyPenalty = 0.0
     var modelName: String = ""
     var maxTokens: Int = 2048
-    var temperature: Double = 0.0
-    var topP: Double = 0.0
+    val presencePenalty: Double = 0.0
     val stream: Boolean = false
     var stop: List<String>? = null
+    var temperature: Double = 0.0
+    var topP: Double = 0.0
     val toolChoice = ToolChoice.AUTO
     override var toolStrategy: ToolUseStrategy = FillInTheBlank
 }
 
+@Suppress("unused")
 internal interface GroqAPI : Extension<Groq> {
     @Serializable
     data class GroqMessage(
@@ -63,6 +76,14 @@ internal interface GroqAPI : Extension<Groq> {
 
         constructor(toolConfig: ToolConfig) : this("function", Function(toolConfig))
     }
+
+    /*
+    ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      ░░░  ░░░░  ░░░      ░░░        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+    ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓        ▓▓  ▓▓▓▓  ▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+    ███████████████████████████████████████  ████  ██  ████  ██        █████  ██████████████████████████████████████████
+    ████████████████████████████████████████      ███  ████  ██  ████  █████  ██████████████████████████████████████████
+    */
 
     @Serializable
     data class ChatRequest(
@@ -181,7 +202,9 @@ interface GroqModels {
     }
 }
 
-private sealed interface GroqActions : NetworkOwner, Actions, Extension<Groq>
+private sealed interface GroqActions : NetworkOwner, Actions, Extension<Groq> {
+
+}
 
 
 class Groq {

--- a/src/main/kotlin/robot/provider/models/Groq.kt
+++ b/src/main/kotlin/robot/provider/models/Groq.kt
@@ -93,7 +93,6 @@ internal interface GroqAPI : Extension<Groq> {
     ███████████████████████████████████████  ████  ██  ████  ██        █████  ██████████████████████████████████████████
     ████████████████████████████████████████      ███  ████  ██  ████  █████  ██████████████████████████████████████████
     */
-
     @Serializable
     data class ChatRequest(
         @SerialName("frequency_penalty")
@@ -112,7 +111,7 @@ internal interface GroqAPI : Extension<Groq> {
         @SerialName("tool_choice")
         val tools: List<Tool> = emptyList(),
         val toolChoice: ToolChoice
-    )
+    ) : CommonChatRequest
 
     @Serializable
     data class ChatResponse(
@@ -144,7 +143,6 @@ internal interface GroqAPI : Extension<Groq> {
         )
     }
 }
-
 
 /*
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  ░░░░  ░░░      ░░░       ░░░        ░░  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

--- a/src/main/kotlin/robot/provider/models/Groq.kt
+++ b/src/main/kotlin/robot/provider/models/Groq.kt
@@ -209,8 +209,27 @@ interface GroqModels {
     }
 }
 
-private sealed interface GroqActions : NetworkOwner, Actions, Extension<Groq> {
+/*
+░░░░░░░░░░░░░░░░░░░░░░░░░░░      ░░░░      ░░░        ░░        ░░░      ░░░   ░░░  ░░░      ░░░░░░░░░░░░░░░░░░░░░░░░░░░
+▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒  ▒▒    ▒▒  ▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓  ▓▓  ▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓  ▓▓▓▓▓  ▓▓▓▓  ▓▓  ▓  ▓  ▓▓▓      ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+██████████████████████████        ██  ████  █████  ████████  █████  ████  ██  ██    ████████  ██████████████████████████
+██████████████████████████  ████  ███      ██████  █████        ███      ███  ███   ███      ███████████████████████████
+ */
+private fun List<ToolConfig>.asGroqTools() = map { GroqAPI.Tool(it) }
+private fun List<Message>.asGroqAIMessage() = this.map { GroqAPI.GroqMessage(it) }
 
+@Suppress("unused")
+private sealed interface GroqActions : NetworkOwner, Actions, Extension<Groq> {
+    override suspend fun chat(tools: List<ToolConfig>): GroqAPI.ChatResponse = with(self()) {
+        post(
+            url, GroqAPI.ChatRequest(
+                frequencyPenalty, model, messenger.messages().asGroqAIMessage(),
+                maxTokens, presencePenalty, stream, stop, temperature, topP,
+                tools.asGroqTools(), toolChoice
+            ), headers
+        )
+    }
 }
 
 /*

--- a/src/main/kotlin/robot/provider/models/Groq.kt
+++ b/src/main/kotlin/robot/provider/models/Groq.kt
@@ -4,9 +4,24 @@ import dev.supachain.Extension
 import dev.supachain.robot.NetworkOwner
 import dev.supachain.robot.provider.Actions
 import dev.supachain.robot.provider.Provider
+import dev.supachain.robot.provider.models.AnthropicAPI.AnthropicMessage
+import dev.supachain.robot.provider.models.AnthropicAPI.ChatRequest.Tool
+import dev.supachain.robot.tool.ToolChoice
+import dev.supachain.robot.tool.strategies.FillInTheBlank
+import dev.supachain.robot.tool.strategies.ToolUseStrategy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 abstract class GroqBuilder : Provider<GroqBuilder>(), NetworkOwner {
-
+    var apiKey: String = ""
+    var modelName: String = ""
+    var maxTokens: Int = 2048
+    var temperature: Double = 0.0
+    var topP: Double = 0.0
+    val stream: Boolean = false
+    var stop: List<String>? = null
+    val toolChoice = ToolChoice.AUTO
+    override var toolStrategy: ToolUseStrategy = FillInTheBlank
 }
 
 internal interface GroqAPI : Extension<Groq> {

--- a/src/main/kotlin/robot/provider/models/Groq.kt
+++ b/src/main/kotlin/robot/provider/models/Groq.kt
@@ -13,12 +13,75 @@ internal interface GroqAPI : Extension<Groq> {
 
 }
 
-class GroqModels {
 
+/*
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  ░░░░  ░░░      ░░░       ░░░        ░░  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒   ▒▒   ▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓        ▓▓  ▓▓▓▓  ▓▓  ▓▓▓▓  ▓▓      ▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+████████████████████████████████████  █  █  ██  ████  ██  ████  ██  ████████  ██████████████████████████████████████████
+████████████████████████████████████  ████  ███      ███       ███        ██        ████████████████████████████████████
+ */
+@Suppress("unused")
+interface GroqModels {
+
+    val models get() = Models
+
+    object Models {
+        val chat = Chat
+        val audio = Audio
+        val vision = Vision
+    }
+
+    object Chat {
+        // Llama 3 Groq Models
+        val llama3Groq70BToolUsePreview: String get() = "llama3-groq-70b-8192-tool-use-preview"
+        val llama3Groq8BToolUsePreview: String get() = "llama3-groq-8b-8192-tool-use-preview"
+
+        // Meta Llama 3.1 Preview Models
+        val llama31_70BPreview: String get() = "llama-3.1-70b-versatile"
+        val llama31_8BPreview: String get() = "llama-3.1-8b-instant"
+
+        // Meta Llama 3.2 Preview Models
+        val llama32_1BTextPreview: String get() = "llama-3.2-1b-preview"
+        val llama32_3BTextPreview: String get() = "llama-3.2-3b-preview"
+        val llama32_11BTextPreview: String get() = "llama-3.2-11b-text-preview"
+        val llama32_90BTextPreview: String get() = "llama-3.2-90b-text-preview"
+
+        // Llama 3.1 Large Model (Offline)
+        val llama31_405B: String get() = "llama-3.1-405b"
+
+        // Meta Llama Guard 3 Model
+        val llamaGuard3_8B: String get() = "llama-guard-3-8b"
+
+        // Meta Llama 3 General
+        val metaLlama3_70B: String get() = "llama3-70b-8192"
+        val metaLlama3_8B: String get() = "llama3-8b-8192"
+
+        // Google's Gemma Models
+        val gemma2_9B: String get() = "gemma2-9b-it"
+        val gemma7B: String get() = "gemma-7b-it"
+
+        // Mistral's Mixtral Model
+        val mixtral8x7B: String get() = "mixtral-8x7b-32768"
+    }
+
+    object Audio {
+        // HuggingFace Distil-Whisper Model
+        val distilWhisperEnglish: String get() = "distil-whisper-large-v3-en"
+
+        // OpenAI Whisper Model
+        val whisperLargeV3: String get() = "whisper-large-v3"
+    }
+
+    object Vision {
+        // Haotian Liu's LLAVA Model
+        val llavaV1_5_7B: String get() = "llava-v1.5-7b-4096-preview"
+    }
 }
 
 private sealed interface GroqActions : NetworkOwner, Actions, Extension<Groq>
 
-class Groq {
 
+class Groq {
 }
+

--- a/src/main/kotlin/robot/provider/models/Groq.kt
+++ b/src/main/kotlin/robot/provider/models/Groq.kt
@@ -1,0 +1,24 @@
+package dev.supachain.robot.provider.models
+
+import dev.supachain.Extension
+import dev.supachain.robot.NetworkOwner
+import dev.supachain.robot.provider.Actions
+import dev.supachain.robot.provider.Provider
+
+abstract class GroqBuilder : Provider<GroqBuilder>(), NetworkOwner {
+
+}
+
+internal interface GroqAPI : Extension<Groq> {
+
+}
+
+class GroqModels {
+
+}
+
+private sealed interface GroqActions : NetworkOwner, Actions, Extension<Groq>
+
+class Groq {
+
+}

--- a/src/main/kotlin/robot/provider/models/Groq.kt
+++ b/src/main/kotlin/robot/provider/models/Groq.kt
@@ -3,10 +3,10 @@ package dev.supachain.robot.provider.models
 import dev.supachain.Extension
 import dev.supachain.robot.NetworkOwner
 import dev.supachain.robot.messenger.Role
+import dev.supachain.robot.messenger.messaging.Usage
 import dev.supachain.robot.provider.Actions
 import dev.supachain.robot.provider.Provider
-import dev.supachain.robot.provider.models.AnthropicAPI.AnthropicMessage
-import dev.supachain.robot.provider.models.AnthropicAPI.ChatRequest.Tool
+
 import dev.supachain.robot.tool.ToolChoice
 import dev.supachain.robot.tool.ToolConfig
 import dev.supachain.robot.tool.strategies.FillInTheBlank
@@ -83,6 +83,36 @@ internal interface GroqAPI : Extension<Groq> {
         val tools: List<Tool> = emptyList(),
         val toolChoice: ToolChoice
     )
+
+    @Serializable
+    data class ChatResponse(
+        val id: String,
+        @SerialName("object")
+        val type: String,
+        val created: Int,
+        val model: String,
+        val choices: List<Choice>,
+        val usage: Usage,
+        @SerialName("service_tier")
+        val serviceTier: String? = null,
+        val systemFingerprint: String? = null,
+        val completion: Boolean? = null,
+        val error: Error? = null
+    ) : Message {
+        @Serializable
+        data class Choice(
+            val index: Int,
+            val message: GroqMessage
+        )
+
+        @Serializable
+        data class Error(
+            val code: Int,
+            val message: String,
+            val type: String,
+            val param: String
+        )
+    }
 }
 
 

--- a/src/main/kotlin/robot/provider/models/Groq.kt
+++ b/src/main/kotlin/robot/provider/models/Groq.kt
@@ -15,7 +15,6 @@ import dev.supachain.utilities.Parameter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-
 /*
 ░░░░░░░░░░░░░░░░░░░░░░░░░░       ░░░  ░░░░  ░░        ░░  ░░░░░░░░       ░░░        ░░       ░░░░░░░░░░░░░░░░░░░░░░░░░░░
 ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
@@ -28,7 +27,6 @@ abstract class GroqBuilder : Provider<GroqBuilder>(), NetworkOwner, GroqModels {
     abstract val model: String
     var apiKey: String = ""
     var frequencyPenalty = 0.0
-    var modelName: String = ""
     var maxTokens: Int = 2048
     val presencePenalty: Double = 0.0
     val stream: Boolean = false
@@ -36,6 +34,15 @@ abstract class GroqBuilder : Provider<GroqBuilder>(), NetworkOwner, GroqModels {
     var temperature: Double = 0.0
     var topP: Double = 0.0
     val toolChoice = ToolChoice.AUTO
+
+    // Network
+    val network: NetworkConfig = NetworkConfig()
+    override var url: String = "https://api.groq.com/openai/v1"
+
+    // Provider
+    override var name: String = "Groq"
+    override var maxRetries: Int = 3
+    override var toolsAllowed: Boolean = true
     override var toolStrategy: ToolUseStrategy = FillInTheBlank
 }
 

--- a/src/main/kotlin/robot/provider/models/LocalAI.kt
+++ b/src/main/kotlin/robot/provider/models/LocalAI.kt
@@ -7,6 +7,7 @@ import dev.supachain.Modifiable
 import dev.supachain.robot.*
 import dev.supachain.robot.messenger.Messenger
 import dev.supachain.robot.messenger.Role
+import dev.supachain.robot.messenger.messaging.ToolCall
 import dev.supachain.robot.provider.Actions
 import dev.supachain.robot.provider.CommonChatRequest
 import dev.supachain.robot.provider.Provider
@@ -72,11 +73,11 @@ class LocalAI : Provider<LocalAI>(), LocalAIActions, NetworkOwner {
 
     override val self: () -> LocalAI get() = { this }
 
-    override fun onToolResult(result: String) {
+    override fun onToolResult(toolCall: ToolCall, result: String) {
         messenger.send(TextMessage(Role.FUNCTION, result))
     }
 
-    override fun onReceiveMessage(message: Message) {
+    override fun onReceiveMessage(message: CommonMessage) {
         messenger.send(message)
     }
 
@@ -92,7 +93,7 @@ class LocalAI : Provider<LocalAI>(), LocalAIActions, NetworkOwner {
         @Serializable
         data class ChatRequest(
             val model: String,
-            val messages: List<Message>,
+            val messages: List<CommonMessage>,
             val temperature: Double,
             @SerialName("top_p")
             val topP: Double,

--- a/src/main/kotlin/robot/provider/models/LocalAI.kt
+++ b/src/main/kotlin/robot/provider/models/LocalAI.kt
@@ -13,7 +13,6 @@ import dev.supachain.robot.provider.Provider
 import dev.supachain.robot.tool.ToolConfig
 import dev.supachain.robot.tool.strategies.BackAndForth
 import dev.supachain.robot.tool.strategies.ToolUseStrategy
-import dev.supachain.utilities.Parameter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -81,22 +80,15 @@ class LocalAI : Provider<LocalAI>(), LocalAIActions, NetworkOwner {
         messenger.send(message)
     }
 
-    /*
-    ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      ░░░       ░░░        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-    ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
-    ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓  ▓▓       ▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-    ████████████████████████████████████████████        ██  ███████████  ███████████████████████████████████████████████
-    ████████████████████████████████████████████  ████  ██  ████████        ████████████████████████████████████████████
-    */
-    interface API {
 
+    interface API {
         /*
-       ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      ░░░  ░░░░  ░░░      ░░░        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-       ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
-       ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓        ▓▓  ▓▓▓▓  ▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-       █████████████████████████████████████  ████  ██  ████  ██        █████  ████████████████████████████████████████
-       ██████████████████████████████████████      ███  ████  ██  ████  █████  ████████████████████████████████████████
-       */
+        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      ░░░  ░░░░  ░░░      ░░░        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+        ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒  ▒▒▒▒  ▒▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+        ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓        ▓▓  ▓▓▓▓  ▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+        █████████████████████████████████████  ████  ██  ████  ██        █████  ████████████████████████████████████████
+        ██████████████████████████████████████      ███  ████  ██  ████  █████  ████████████████████████████████████████
+        */
         @Serializable
         data class ChatRequest(
             val model: String,
@@ -108,40 +100,10 @@ class LocalAI : Provider<LocalAI>(), LocalAIActions, NetworkOwner {
             val topK: Int,
             @SerialName("max_tokens")
             val maxTokens: Int,
-            val tools: List<Tool> = emptyList(),
-        ) : CommonChatRequest {
-            @Serializable
-            data class Tool(val type: String, val function: Function) {
-                @Serializable
-                data class Function(val name: String, val description: String?, val parameters: Parameters) {
-                    @Serializable
-                    data class Parameters(
-                        val type: String,
-                        val properties: Map<String, Property>,
-                        val required: List<String>
-                    ) {
-                        constructor(parameters: List<Parameter>) : this(
-                            "object",
-                            parameters.toProperties(),
-                            parameters.filter { it.required }.map { it.name }
-                        )
-                    }
-
-                    constructor(toolConfig: ToolConfig) :
-                            this(
-                                toolConfig.function.name,
-                                toolConfig.function.description.ifBlank { null },
-                                Parameters(toolConfig.function.parameters)
-                            )
-                }
-
-                constructor(toolConfig: ToolConfig) : this("function", Function(toolConfig))
-            }
-        }
-
+            val tools: List<CommonTool.OpenAI> = emptyList(),
+        ) : CommonChatRequest
     }
 }
-
 
 /*
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░      ░░░░      ░░░        ░░        ░░░      ░░░   ░░░  ░░░      ░░░░░░░░░░░░░░░░░░░░░░░░░░░
@@ -149,15 +111,13 @@ class LocalAI : Provider<LocalAI>(), LocalAIActions, NetworkOwner {
 ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓  ▓▓  ▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓  ▓▓▓▓▓  ▓▓▓▓  ▓▓  ▓  ▓  ▓▓▓      ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 ██████████████████████████        ██  ████  █████  ████████  █████  ████  ██  ██    ████████  ██████████████████████████
 ██████████████████████████  ████  ███      ██████  █████        ███      ███  ███   ███      ███████████████████████████
- */
-private fun List<ToolConfig>.asLocalAITools() = map { LocalAI.API.ChatRequest.Tool(it) }
-
+*/
 private sealed interface LocalAIActions : NetworkOwner, Actions, Extension<LocalAI> {
     override suspend fun chat(tools: List<ToolConfig>): OpenAIAPI.ChatResponse = with(self()) {
         return post(
             "$url/v1/chat/completions", LocalAI.API.ChatRequest(
                 chatModel, messenger.messages(),
-                temperature, topP, topK, maxTokens, tools.asLocalAITools()
+                temperature, topP, topK, maxTokens, tools.asOpenAITools()
             )
         )
     }

--- a/src/main/kotlin/robot/provider/models/OpenAI.kt
+++ b/src/main/kotlin/robot/provider/models/OpenAI.kt
@@ -116,10 +116,7 @@ class OpenAI : Provider<OpenAI>(), OpenAIActions, OpenAIModels {
     val toolChoice = ToolChoice.AUTO
     val user: String? = null
 
-    internal val headers
-        get() = mutableMapOf(
-            HttpHeaders.Authorization to "Bearer $apiKey"
-        )
+    internal val headers get() = mutableMapOf(HttpHeaders.Authorization to "Bearer $apiKey")
 
     companion object : Modifiable<OpenAI>({ OpenAI() })
 

--- a/src/main/kotlin/robot/provider/models/OpenAI.kt
+++ b/src/main/kotlin/robot/provider/models/OpenAI.kt
@@ -17,7 +17,6 @@ import dev.supachain.robot.tool.ToolChoice
 import dev.supachain.robot.tool.ToolConfig
 import dev.supachain.robot.tool.strategies.BackAndForth
 import dev.supachain.robot.tool.strategies.ToolUseStrategy
-import dev.supachain.utilities.Parameter
 import dev.supachain.utilities.toJson
 import io.ktor.http.*
 import kotlinx.serialization.SerialName
@@ -139,7 +138,6 @@ class OpenAI : Provider<OpenAI>(), OpenAIActions, OpenAIModels {
 ██████████████████████████████████████████████        ██  ███████████  █████████████████████████████████████████████████
 ██████████████████████████████████████████████  ████  ██  ████████        ██████████████████████████████████████████████
 */
-private fun List<ToolConfig>.asOpenAITools() = map { OpenAIAPI.Tool(it) }
 
 interface OpenAIAPI {
 
@@ -155,33 +153,6 @@ interface OpenAIAPI {
         constructor(message: Message) : this(message.role(), message.text().value)
     }
 
-    @Serializable
-    data class Tool(val type: String, val function: Function) {
-        @Serializable
-        data class Function(val name: String, val description: String?, val parameters: Parameters) {
-            @Serializable
-            data class Parameters(
-                val type: String,
-                val properties: Map<String, Property>,
-                val required: List<String>
-            ) {
-                constructor(parameters: List<Parameter>) : this(
-                    "object",
-                    parameters.toProperties(),
-                    parameters.filter { it.required }.map { it.name }
-                )
-            }
-
-            constructor(toolConfig: ToolConfig) :
-                    this(
-                        toolConfig.function.name,
-                        toolConfig.function.description.ifBlank { null },
-                        Parameters(toolConfig.function.parameters)
-                    )
-        }
-
-        constructor(toolConfig: ToolConfig) : this("function", Function(toolConfig))
-    }
 
     /*
     ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░      ░░░  ░░░░  ░░░      ░░░        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
@@ -206,7 +177,7 @@ interface OpenAIAPI {
         val stream: Boolean,
         val temperature: Double,
         @SerialName("top_p") val topP: Double,
-        val tools: List<Tool>,
+        val tools: List<CommonTool.OpenAI>,
         @SerialName("tool_choice") val toolChoice: ToolChoice,
         val user: String?
     ) : CommonChatRequest

--- a/src/main/kotlin/robot/tool/strategies/FillInTheBlank.kt
+++ b/src/main/kotlin/robot/tool/strategies/FillInTheBlank.kt
@@ -4,7 +4,7 @@ import dev.supachain.robot.director.RobotCore
 import dev.supachain.robot.director.asFunctionCall
 import dev.supachain.robot.messenger.ToolResultAction
 import dev.supachain.robot.messenger.ToolResultMessage
-import dev.supachain.robot.provider.models.Message
+import dev.supachain.robot.provider.models.CommonMessage
 import dev.supachain.robot.provider.models.TextMessage
 import dev.supachain.robot.provider.models.asAssistantMessage
 import dev.supachain.robot.provider.models.asSystemMessage
@@ -36,7 +36,7 @@ data object FillInTheBlank : ToolUseStrategy {
      */
     internal class Result(
         override var action: ToolResultAction = ToolResultAction.Complete,
-        override val messages: MutableList<Message> = mutableListOf(),
+        override val messages: MutableList<CommonMessage> = mutableListOf(),
     ) : ToolResultMessage
 
     /**
@@ -119,7 +119,7 @@ data object FillInTheBlank : ToolUseStrategy {
      *
      * @since 0.1.0
      */
-    operator fun invoke(robot: RobotCore<*, *, *>, response: Message): ToolResultMessage = with(robot) {
+    operator fun invoke(robot: RobotCore<*, *, *>, response: CommonMessage): ToolResultMessage = with(robot) {
         val template = response.text().toString().templates()
         val results = template.expressions.map { it.asFunctionCall()().toString() }
         Result(ToolResultAction.ReplaceAndComplete).apply {

--- a/src/main/kotlin/robot/tool/strategies/ToolUseStrategy.kt
+++ b/src/main/kotlin/robot/tool/strategies/ToolUseStrategy.kt
@@ -1,6 +1,6 @@
 package dev.supachain.robot.tool.strategies
 
-import dev.supachain.robot.provider.models.Message
+import dev.supachain.robot.provider.models.CommonMessage
 import dev.supachain.robot.tool.ToolConfig
 
 /**
@@ -14,6 +14,6 @@ import dev.supachain.robot.tool.ToolConfig
 
  */
 sealed interface ToolUseStrategy {
-    fun onRequestMessage(toolSet: List<ToolConfig>): Message?
+    fun onRequestMessage(toolSet: List<ToolConfig>): CommonMessage?
     fun getTools(tools: List<ToolConfig>): List<ToolConfig>
 }

--- a/src/test/kotlin/GroqTesting.kt
+++ b/src/test/kotlin/GroqTesting.kt
@@ -1,0 +1,391 @@
+import dev.supachain.robot.Defaults
+import dev.supachain.robot.Robot
+import dev.supachain.robot.messenger.MessageFilter
+import dev.supachain.robot.provider.models.Groq
+import dev.supachain.robot.provider.models.GroqException
+import dev.supachain.robot.tool.Parameters
+import dev.supachain.robot.tool.Tool
+import dev.supachain.robot.tool.ToolSet
+import dev.supachain.robot.tool.strategies.BackAndForth
+import dev.supachain.utilities.Debug
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import io.ktor.utils.io.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+
+class GroqTesting {
+
+    private fun String.asJSON() = Json.parseToJsonElement(this).jsonObject
+
+    // language=JSON
+    private val expectedSimpleRequest = """
+        {
+          "frequency_penalty": 0.0,
+          "max_tokens": 2048,
+          "messages": [
+            {
+              "role": "user",
+              "content": "Hi!"
+            }
+          ],
+          "model": "llama-3.1-70b-versatile",
+          "presence_penalty": 0.0,
+          "stop": null,
+          "stream": false,
+          "temperature": 0.0,
+          "tool_choice": "auto",
+          "top_p": 0.0
+        }
+    """
+
+    // language=JSON
+    private val expectedSimpleSuccessResponse = """
+        {
+          "id": "chatcompletion_123456",
+          "created": 1643723400,
+          "model": "llama-3.1-70b-versatile",
+          "serviceTier": "standard",
+          "systemFingerprint": "abcdefg",
+          "object": "chat.completion",
+          "completion": true,
+          "usage": {
+            "prompt_tokens": 24,
+            "completion_tokens": 377,
+            "total_tokens": 401,
+            "prompt_time": 0.009,
+            "completion_time": 0.774,
+            "total_time": 0.783
+          },
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Hi"
+              },
+              "logprobs": null,
+              "finish_reason": "finish"
+            }
+          ],
+          "error": null
+        }
+    """
+
+    // language=JSON
+    private val expectedToolCallRequest = """
+        {
+          "frequency_penalty": 0.0,
+          "max_tokens": 2048,
+          "messages": [
+            {
+              "role": "user",
+              "content": "What is the weather like in San Francisco today?"
+            }
+          ],
+          "model": "llama-3.1-70b-versatile",
+          "presence_penalty": 0.0,
+          "stop": null,
+          "stream": false,
+          "temperature": 0.0,
+          "tool_choice": "auto",
+          "top_p": 0.0,
+          "tools": [
+            {
+              "type": "function",
+              "function": {
+                "name": "getWeather",
+                "description": "Get the current weather for a given location",
+                "parameters": {
+                  "type": "object",
+                  "properties": {
+                    "location": {
+                      "type": "string",
+                      "description": "The city and state, e.g. San Francisco, CA"
+                    },
+                    "unit": {
+                      "type": "string",
+                      "enum": ["Celsius", "Fahrenheit"]
+                    }
+                  },
+                  "required": ["location"]
+                }
+              }
+            }
+          ]
+        }
+    """
+
+    // language=JSON
+    private val expectedToolCallSuccessResponse = """
+        {
+          "id": "chatcompletion_123456",
+          "created": 1643723400,
+          "model": "llama-3.1-70b-versatile",
+          "serviceTier": "standard",
+          "systemFingerprint": "abcdefg",
+          "object": "chat.completion",
+          "completion": true,
+          "usage": {
+            "prompt_tokens": 24,
+            "completion_tokens": 377,
+            "total_tokens": 401,
+            "prompt_time": 0.009,
+            "completion_time": 0.774,
+            "total_time": 0.783
+          },
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                      "id": "call_123",
+                      "type": "function",
+                      "name": "getWeather",
+                      "function": {
+                          "name": "getWeather",
+                          "arguments": "{\"location\": \"San Francisco, CA\"}"
+                      }
+                    }
+                  ]
+              },
+              "logprobs": null,
+              "finish_reason": "tool_calls"
+            }
+          ],
+          "error": null
+        }
+    """
+
+    // language=JSON
+    private val expectedToolResultRequest = """
+        {
+          "frequency_penalty": 0.0,
+          "max_tokens": 2048,
+          "messages": [
+            {
+              "role": "user",
+              "content": "What is the weather like in San Francisco today?"
+            },
+            {
+              "role": "assistant",
+              "content": "",
+              "tool_calls": [
+                  {
+                      "id": "call_123",
+                      "type": "function",
+                      "function": {
+                          "name": "getWeather",
+                          "arguments": "{\"location\": \"San Francisco, CA\"}"
+                      }
+                  }
+              ]
+            },
+            {
+              "role": "tool",
+              "content": "27",
+              "tool_call_id": "call_123"
+            }
+          ],
+          "model": "llama-3.1-70b-versatile",
+          "presence_penalty": 0.0,
+          "stop": null,
+          "stream": false,
+          "temperature": 0.0,
+          "tool_choice": "auto",
+          "top_p": 0.0,
+          "tools": [
+            {
+              "type": "function",
+              "function": {
+                "name": "getWeather",
+                "description": "Get the current weather for a given location",
+                "parameters": {
+                  "type": "object",
+                  "properties": {
+                    "location": {
+                      "type": "string",
+                      "description": "The city and state, e.g. San Francisco, CA"
+                    },
+                    "unit": {
+                      "type": "string",
+                      "enum": ["Celsius", "Fahrenheit"]
+                    }
+                  },
+                  "required": ["location"]
+                }
+              }
+            }
+          ]
+        }
+    """
+
+    // language=JSON
+    private val expectedToolResultSuccessResponse = """
+        {
+          "id": "chatcompletion_123456",
+          "object": "chat.completion",
+          "created": 1643723400,
+          "model": "llama-3.1-70b-versatile",
+          "systemFingerprint": "abcdefg",
+          "serviceTier": "standard",
+          "completion": true,
+          "usage": {
+            "prompt_tokens": 24,
+            "completion_tokens": 377,
+            "total_tokens": 401,
+            "prompt_time": 0.009,
+            "completion_time": 0.774,
+            "total_time": 0.783
+          },
+          "choices": [
+            {
+             "message": {
+                    "role": "assistant",
+                    "content": "The current temperature in San Francisco, CA is 27°C."
+                  },
+              "finish_reason": "stop",
+              "index": 0
+            }
+          ],
+          "error": null
+        }
+    """
+
+    // language=JSON
+    val expectedErrorMessage = """
+        {
+          "error": {
+            "message": "String - description of the specific error",
+            "type": "invalid_request_error"
+          }
+        }
+    """.trimIndent()
+
+    @ToolSet
+    class Tools {
+        @Tool("Get the current weather for a given location")
+        @Parameters(["The city and state, e.g. San Francisco, CA"])
+        fun getWeather(location: String, unit: Unit = Unit.Celsius): Int = 27
+        enum class Unit { Celsius, Fahrenheit }
+    }
+
+    private fun testBot(mockEngine: MockEngine) =
+        Robot<Groq, Defaults.Chat, Tools> {
+            Debug show "Network"
+            defaultProvider {
+                apiKey = "API_KEY"
+                network.engine = { mockEngine }
+                useFormatMessage = false
+                userMessagePrimer = false
+                messageFilter = MessageFilter.OnlyUserMessages
+                model = models.chat.llama31_70BVersatile
+                toolStrategy = BackAndForth
+            }
+        }
+
+    private fun MockRequestHandleScope.simpleSuccessResponse() = respond(
+        ByteReadChannel(expectedSimpleSuccessResponse),
+        HttpStatusCode.OK,
+        headersOf(HttpHeaders.ContentType, "application/json")
+    )
+
+    private fun MockRequestHandleScope.errorResponse() = respond(
+        ByteReadChannel(expectedErrorMessage),
+        HttpStatusCode.OK,
+        headersOf(HttpHeaders.ContentType, "application/json")
+    )
+
+    private fun MockRequestHandleScope.toolCallSuccessResponse() = respond(
+        ByteReadChannel(expectedToolCallSuccessResponse),
+        HttpStatusCode.OK,
+        headersOf(HttpHeaders.ContentType, "application/json")
+    )
+
+    private fun MockRequestHandleScope.toolResultSuccessResponse() = respond(
+        ByteReadChannel(expectedToolResultSuccessResponse),
+        HttpStatusCode.OK,
+        headersOf(HttpHeaders.ContentType, "application/json")
+    )
+
+
+    @Test
+    fun `Has Correct URL and Headers`() {
+        val mockEngine = MockEngine { request ->
+            // Ensure the correct request details
+            assertEquals("https://api.groq.com/openai/v1/chat/completions", request.url.toString())
+            assertEquals("Bearer API_KEY", request.headers[HttpHeaders.Authorization])
+            simpleSuccessResponse()
+        }
+
+        testBot(mockEngine).chat("").await()
+    }
+
+    @Test
+    fun `Has Correct Request (simple)`() {
+        val mockEngine = MockEngine { request ->
+            val requestJSON = Json.decodeFromString<JsonObject>(request.body.toByteArray().decodeToString())
+            assertTrue(expectedSimpleRequest.asJSON().isContainedIn(requestJSON))
+            simpleSuccessResponse()
+        }
+
+        testBot(mockEngine).chat("Hi!").await()
+    }
+
+    @Test
+    fun `Has Correct Response (simple)`() {
+        val mockEngine = MockEngine { _ -> simpleSuccessResponse() }
+        val response = testBot(mockEngine).chat("").await()
+
+        assertEquals("Hi", response)
+    }
+
+    @Test
+    fun `Has Correct Request (tool call)`() {
+        var messageNumber = 0
+        val mockEngine = MockEngine { request ->
+            val requestJSON = Json.decodeFromString<JsonObject>(request.body.toByteArray().decodeToString())
+            when (messageNumber++) {
+                0 -> {
+                    assertTrue(expectedToolCallRequest.asJSON().isContainedIn(requestJSON))
+                    toolCallSuccessResponse()
+                }
+
+                else -> {
+                    assertTrue(expectedToolResultRequest.asJSON().isContainedIn(requestJSON))
+                    toolResultSuccessResponse()
+                }
+            }
+        }
+
+        testBot(mockEngine).chat("What is the weather like in San Francisco today?").await()
+    }
+
+    @Test
+    fun `Has Correct Response (tool call)`() {
+        var messageNumber = 0
+        val mockEngine = MockEngine { request ->
+            when (messageNumber++) {
+                0 -> toolCallSuccessResponse()
+                else -> toolResultSuccessResponse()
+            }
+        }
+
+        val response = testBot(mockEngine).chat("What is the weather like in San Francisco today?").await()
+        assertEquals("The current temperature in San Francisco, CA is 27°C.", response)
+    }
+
+    @Test
+    fun `Has Error Response`() {
+        val mockEngine = MockEngine { _ -> errorResponse() }
+        assertThrows<GroqException> { testBot(mockEngine).chat("").await() }
+    }
+}

--- a/src/test/kotlin/OpenAITesting.kt
+++ b/src/test/kotlin/OpenAITesting.kt
@@ -306,4 +306,6 @@ class OpenAITesting {
     }
 """.trimIndent()
     }
+
+
 }


### PR DESCRIPTION
This PR introduces a new Groq integration module within Supachain.
Key Changes:
- Provider Implementation: Introduced Groq provider with builder, API, models, and actions
- Added definitions for: LLaMA, Meta LLaMA, LLaMA Guard, Gemma, Mixtral, Distil-Whisper, Whisper, LLAVA
- Implemented Groq Chat Request/ Chat Response API
- Added Groq Network and Provider defaults
- Created Groq Builder for easy configuration
- Added Groq Chat action for seamless interactions
- Added tests in GroqTesting.kt:
   - Test suite for Groq API requests and responses
   - Covers simple requests, tool calls, error handling, and response parsing
   - Verifies information requests with and without tool calls
   - Checks headers for API key and URL validation
  
closes #70