### PR TITLE
Bug Fix: Corrected Groq Request Parameters

### DIFF
--- a/src/main/kotlin/robot/provider/models/Groq.kt
+++ b/src/main/kotlin/robot/provider/models/Groq.kt
@@ -97,6 +97,7 @@ internal interface GroqAPI : Extension<Groq> {
         val frequencyPenalty: Double,
         @SerialName("logit_bias")
         val logitBias: Map<String, Int>?,
+        @SerialName("logprobs")
         val logProbabilities: Boolean?,
         val model: String,
         val messages: List<Message>,
@@ -105,6 +106,7 @@ internal interface GroqAPI : Extension<Groq> {
         val n: Int? = null,
         @SerialName("presence_penalty")
         val presencePenalty: Double,
+        @SerialName("response_format")
         val responseFormat: GroqResponseFormat?,
         val seed: Int? = null,
         val stream: Boolean? = null,

--- a/src/test/kotlin/GroqTesting.kt
+++ b/src/test/kotlin/GroqTesting.kt
@@ -37,6 +37,9 @@ class GroqTesting {
           "model": "llama-3.1-70b-versatile",
           "presence_penalty": 0.0,
           "stop": null,
+          "logprobs": null,
+          "logit_bias": null,
+          "response_format": null,
           "stream": false,
           "temperature": 0.0,
           "tool_choice": "auto",
@@ -91,6 +94,9 @@ class GroqTesting {
           "model": "llama-3.1-70b-versatile",
           "presence_penalty": 0.0,
           "stop": null,
+          "logprobs": null,
+          "logit_bias": null,
+          "response_format": null,
           "stream": false,
           "temperature": 0.0,
           "tool_choice": "auto",
@@ -156,8 +162,10 @@ class GroqTesting {
                       }
                     }
                   ]
-              },
+              }, 
               "logprobs": null,
+              "logit_bias": null,
+              "response_format": null,
               "finish_reason": "tool_calls"
             }
           ],
@@ -201,6 +209,9 @@ class GroqTesting {
           "stream": false,
           "temperature": 0.0,
           "tool_choice": "auto",
+          "logprobs": null,
+          "logit_bias": null,
+          "response_format": null,
           "top_p": 0.0,
           "tools": [
             {


### PR DESCRIPTION
This PR addresses a bug in the Groq implementation that resulted in incorrect request parameters being sent to the Groq server. The issue was caused by using incorrect key names during the request.
 - The serial names for request parameters have been updated to match the expected format by the Groq server.
 - This fix prevents errors on the Groq server side that were previously occurring due to invalid parameter values
 - The tests have been updated to test for these keys